### PR TITLE
Break after each case in number builder

### DIFF
--- a/src/zod-fast-check.ts
+++ b/src/zod-fast-check.ts
@@ -264,8 +264,10 @@ const arbitraryBuilders: ArbitraryBuilders = {
             max,
             check.inclusive ? check.value : check.value - 0.001
           );
+          break;
         case "int":
           isInt = true;
+          break;
       }
     }
 

--- a/tests/zod-fast-check.test.ts
+++ b/tests/zod-fast-check.test.ts
@@ -80,6 +80,7 @@ describe("Generate arbitraries for Zod schema input types", () => {
     // Schemas which rely on refinements
     "number with minimum": z.number().min(500),
     "number with maximum": z.number().max(500),
+    "number with float max and min": z.number().min(0.5).max(1.5),
     int: z.number().int(),
     positive: z.number().positive(),
     negative: z.number().negative(),


### PR DESCRIPTION
Thanks for a great project!

I noticed while running this with the latest version of fast-check (2.24.0) that a float with a max value fails with:

```
fc.integer maximum value should be an integer
```

It looks like dubzzz/fast-check#2465 added param validation that uncovered this issue.

The test case I added passes under 2.0.0 since there's no validation, but fails on newer versions.