### PR TITLE
fix(set): handle non-empty sets

### DIFF
--- a/src/zod-fast-check.ts
+++ b/src/zod-fast-check.ts
@@ -350,8 +350,11 @@ const arbitraryBuilders: ArbitraryBuilders = {
     return fc.array(fc.tuple(key, value)).map((entries) => new Map(entries));
   },
   ZodSet(schema: ZodSet, path: string, recurse: SchemaToArbitrary) {
+    const minSize = schema._def.minSize?.value ?? 0;
+    const maxSize = Math.min(schema._def.maxSize?.value ?? 10, 10);
+
     return fc
-      .set(recurse(schema._def.valueType, path + ".(value)"))
+      .set(recurse(schema._def.valueType, path + ".(value)"), minSize, maxSize)
       .map((members) => new Set(members));
   },
   ZodFunction(

--- a/tests/zod-fast-check.test.ts
+++ b/tests/zod-fast-check.test.ts
@@ -82,6 +82,9 @@ describe("Generate arbitraries for Zod schema input types", () => {
       z.array(z.boolean())
     ),
     set: z.set(z.number()),
+    "nonempty set": z.set(z.number()).nonempty(),
+    "set with min": z.set(z.number()).min(2),
+    "set with max": z.set(z.number()).max(3),
     "function returning boolean": z.function().returns(z.boolean()),
     "literal number": z.literal(123.5),
     "literal string": z.literal("hello"),


### PR DESCRIPTION
Zod allows to pass `.nonempty()`, `.min()`, `.max()` to Sets (like Arrays). these PR handles this