### PR TITLE
Add support for key schemas in records

### DIFF
--- a/src/zod-fast-check.ts
+++ b/src/zod-fast-check.ts
@@ -397,7 +397,7 @@ const arbitraryBuilders: ArbitraryBuilders = {
   },
   ZodRecord(schema: ZodRecord, path: string, recurse: SchemaToArbitrary) {
     return fc.dictionary(
-      fc.string(),
+      recurse(schema._def.keyType, path),
       recurse(schema._def.valueType, path + "[*]")
     );
   },

--- a/tests/zod-fast-check.test.ts
+++ b/tests/zod-fast-check.test.ts
@@ -78,6 +78,9 @@ describe("Generate arbitraries for Zod schema input types", () => {
     "nested tuple": z.tuple([z.string(), z.tuple([z.number()])]),
     "record of numbers": z.record(z.number()),
     "record of objects": z.record(z.object({ name: z.string() })),
+    "record of strings": z.record(z.string()),
+    "record of strings with min-length values": z.record(z.string().min(1)),
+    "record of strings with min-length keys": z.record(z.string().min(1), z.string()),
     "map with string keys": z.map(z.string(), z.number()),
     "map with object keys": z.map(
       z.object({ id: z.number() }),


### PR DESCRIPTION
Fix for `z.records` that have key requirements.

```
ZodFastCheck.inputOf(
  z.record(
    z.string().min(1),
    z.string()
  )
) // => Arbitrary sometimes produces key-length of 0 ({ "": "" }) even though schema sets min-length of 1
```


Not 100% sure I am using `recurse` correctly. Assuming you'll know better if that's not the right fix here. Tests seem to be happy.
Really appreciate this library. It's been wonderful so far @DavidTimms :tada: 